### PR TITLE
Fix $selectize-width-item-border

### DIFF
--- a/dist/css/selectize.bootstrap4.css
+++ b/dist/css/selectize.bootstrap4.css
@@ -33,7 +33,7 @@
   -moz-border-radius: 0.25rem;
   border-radius: 0.25rem; }
   .selectize-control.multi .selectize-input.has-items {
-    padding: calc(0.375rem - 1px - 0) 0.75rem calc(0.375rem - 1px - 3px - 0); }
+    padding: calc(0.375rem - 1px - 0px) 0.75rem calc(0.375rem - 1px - 3px - 0px); }
   .selectize-input.full {
     background-color: #fff; }
   .selectize-input.disabled, .selectize-input.disabled * {
@@ -57,15 +57,15 @@
     padding: 1px 3px;
     background: #efefef;
     color: #343a40;
-    border: 0 solid #999; }
+    border: 0px solid #999; }
     .selectize-control.multi .selectize-input > div.active {
       background: #007bff;
       color: #fff;
-      border: 0 solid rgba(0, 0, 0, 0); }
+      border: 0px solid rgba(0, 0, 0, 0); }
   .selectize-control.multi .selectize-input.disabled > div, .selectize-control.multi .selectize-input.disabled > div.active {
     color: #878787;
     background: white;
-    border: 0 solid #e6e6e6; }
+    border: 0px solid #e6e6e6; }
   .selectize-input > input {
     display: inline-block !important;
     padding: 0 !important;

--- a/src/selectize/selectize.bootstrap4.scss
+++ b/src/selectize/selectize.bootstrap4.scss
@@ -39,7 +39,7 @@ $selectize-shadow-input-error-focus: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6p
 $selectize-border: 1px solid $input-border-color !default;
 $selectize-border-radius: $input-border-radius !default;
 
-$selectize-width-item-border: 0 !default;
+$selectize-width-item-border: 0px !default;
 $selectize-padding-x: $input-btn-padding-x !default;
 $selectize-padding-y: $input-btn-padding-y !default;
 $selectize-padding-dropdown-item-x: $input-btn-padding-x !default;


### PR DESCRIPTION
When unit is not specified in this variable, `calc` function fails in `selectize.scss` lines 122 and 123, which makes selectize incorrectly padded when it's in multiple mode and it has at least one item selected.

![Screenshot of failing property](https://i.imgur.com/DUXw38x.png)