### PR TITLE
Update focus state of selectize input

### DIFF
--- a/dist/css/selectize.bootstrap4.css
+++ b/dist/css/selectize.bootstrap4.css
@@ -327,7 +327,8 @@
   padding: 6px 0.75rem; }
 
 .selectize-input {
-  min-height: calc(2.25rem + 2px); }
+  min-height: calc(2.25rem + 2px);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
   .selectize-input.dropdown-active {
     -webkit-border-radius: 0.25rem;
     -moz-border-radius: 0.25rem;
@@ -335,10 +336,9 @@
   .selectize-input.dropdown-active::before {
     display: none; }
   .selectize-input.focus {
-    border-color: #adb5bd;
+    border-color: #80bdff;
     outline: 0;
-    -webkit-box-shadow: none;
-    box-shadow: none; }
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
 
 .is-invalid .selectize-input {
   border-color: #dc3545;

--- a/src/selectize/selectize.bootstrap4.scss
+++ b/src/selectize/selectize.bootstrap4.scss
@@ -106,20 +106,23 @@ $selectize-arrow-offset: calc(#{$selectize-padding-x} + 5px) !default;
 
 .selectize-input {
   min-height: $input-height;
+  @include box-shadow($input-box-shadow);
+  @include transition($input-transition);
 
   &.dropdown-active {
-	@include selectize-border-radius($selectize-border-radius);
+    @include selectize-border-radius($selectize-border-radius);
   }
   &.dropdown-active::before {
-	display: none;
+    display: none;
   }
   &.focus {
-	$color: $gray-500;
-	//$color-rgba: rgba(red($color), green($color), blue($color), .6);
-	border-color: $color;
-	outline: 0;
-	@include selectize-box-shadow(none)
-  	//@include selectize-box-shadow(#{"inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px ${color-rgba}"});
+    border-color: $input-focus-border-color;
+    outline: 0;
+    @if $enable-shadows {
+      box-shadow: $input-box-shadow, $input-focus-box-shadow;
+    } @else {
+      box-shadow: $input-focus-box-shadow;
+    }
   }
 }
 


### PR DESCRIPTION
Some cosmetic updates:

1. Add inset shadow to the input when `$enable-shadows` is set.
2. Add cool-looking primary-color outline when input is in focus (screenshot below).
3. Update input border color in focus state

![Screenshot of selectize input in focus state](https://i.imgur.com/lfnWo4K.png)