### PR TITLE
Avoid deprecated nav-divider()

### DIFF
--- a/src/selectize/selectize.bootstrap4.scss
+++ b/src/selectize/selectize.bootstrap4.scss
@@ -86,7 +86,10 @@ $selectize-arrow-offset: calc(#{$selectize-padding-x} + 5px) !default;
   .optgroup:before {
 	content: ' ';
 	display: block;
-	@include nav-divider();
+	height: 0;
+	margin: $dropdown-divider-margin-y 0;
+	overflow: hidden;
+	border-top: 1px solid $dropdown-divider-bg;
 	margin-left: $selectize-padding-dropdown-item-x * -1;
 	margin-right: $selectize-padding-dropdown-item-x * -1;
   }


### PR DESCRIPTION
The nav-divider() mixin is soft-deprecated in Bootstrap4 (i.e., it emits a warning) and it has already been officially [dropped in Bootstrap 5](https://github.com/twbs/bootstrap/pull/29285)